### PR TITLE
Fix/validate indexed colors

### DIFF
--- a/src/tools/snes_palette_exporter.lua
+++ b/src/tools/snes_palette_exporter.lua
@@ -5,6 +5,13 @@ local color_converter = require("src.color_converter")
 local sprite = app.sprite
 local shades = {}
 
+local errors = {
+    noSprite = "There is no sprite open",
+    colorMode = "Sprite color mode must be indexed",
+    width = "Sprite width needs to be a multiple of 8",
+    height = "Sprite height needs to be a multiple of 8"
+}
+
 -------------------------------------------------------------------
 -- HELPER METHODS
 -------------------------------------------------------------------
@@ -24,10 +31,42 @@ local function getHexadecimalPalette()
     return colors
 end
 
+local function showError(message)
+    app.alert{title="Error", text=message, buttons="OK"}
+end
+
+local function isSpriteValid()
+    if not sprite then
+        showError(errors.noSprite)
+        return false
+    end
+
+    if sprite.colorMode ~= ColorMode.INDEXED then
+        showError(errors.colorMode)
+        return false
+    end
+
+    if (sprite.width % 8) ~= 0 then
+        showError(errors.width)
+        return false
+    end
+
+    if (sprite.height % 8) ~= 0 then
+        showError(errors.height)
+        return false
+    end
+
+    return true
+end
+
 -------------------------------------------------------------------
 -- METHODS
 -------------------------------------------------------------------
 local function exportPalette()
+    if not isSpriteValid() then
+		return
+	end
+
     local currentPalette = getHexadecimalPalette()
     local getPaletteHex = color_converter.GetPaletteHex(currentPalette)
 

--- a/version_control.json
+++ b/version_control.json
@@ -1,9 +1,9 @@
 {
     "toolkit_name": "Retro Artist Toolkit",
-    "toolkit_version": "0.1.0",
+    "toolkit_version": "0.1.1",
     "tools": {
       "snes_palette_exporter": {
-        "version": "1.0.0"
+        "version": "1.0.1"
       }
     }
   }


### PR DESCRIPTION
Now it only exports palettes if the colors are indexed

<img width="805" alt="Screenshot 2024-06-16 at 10 07 57" src="https://github.com/maganharenan/retro-artist-toolkit/assets/49283148/ab987f6d-6f32-495b-99bb-a4d245e1984d">
