### PR TITLE
[FIX][9] remove returns from dependencies

### DIFF
--- a/compiler/build_toolkit.lua
+++ b/compiler/build_toolkit.lua
@@ -61,6 +61,7 @@ for _, tool in ipairs(tool_list) do
         Logger:print("Importing: " .. dependency_name, Logger.Colors.CYAN)
 
         local dependency_content = file_manager:readFile(dependency)
+        dependency_content = file_cleaner:removeReturnLine(dependency_content, dependency_name)
 
         combined_dependecies = combined_dependecies .. addDependencyHeader(dependency_name)
 

--- a/compiler/file_cleaner.lua
+++ b/compiler/file_cleaner.lua
@@ -2,6 +2,24 @@ local Logger = require("logger")
 
 local file_cleaner = {}
 
+function file_cleaner:removeReturnLine(content, dependency)
+    local baseName = dependency:gsub("%.lua$", "")
+
+    Logger:print(Logger.Weight.BOLD .. "Removing return " .. baseName, Logger.Colors.CYAN)
+
+    local lines = {}
+
+    for line in content:gmatch("(.-)\n") do
+        if line ~= "return " .. dependency then
+            table.insert(lines, line)
+        end
+    end
+
+    print(content)
+
+    return table.concat(lines, "\n")
+end
+
 function file_cleaner:removeComments(content)
     Logger:print(Logger.Weight.BOLD .. "[PROCESS] *** REMOVING COMMENTS ***", Logger.Colors.CYAN)
 
@@ -12,7 +30,7 @@ function file_cleaner:removeComments(content)
         end
     end
 
-    Logger:print("Comments were successfully remover", Logger.Colors.GREEN)
+    Logger:print("Comments were successfully removed", Logger.Colors.GREEN)
     Logger:divider(Logger.Colors.CYAN)
     return table.concat(lines, "\n")
 end


### PR DESCRIPTION
I implemented a method to remove the return lines

``` lua
function file_cleaner:removeReturnLine(content, dependency)
    local baseName = dependency:gsub("%.lua$", "")

    Logger:print(Logger.Weight.BOLD .. "Removing return " .. baseName, Logger.Colors.CYAN)

    local lines = {}

    for line in content:gmatch("(.-)\n") do
        if line ~= "return " .. dependency then
            table.insert(lines, line)
        end
    end

    return table.concat(lines, "\n")
end

```